### PR TITLE
check if field is editable

### DIFF
--- a/django_reverse_admin/__init__.py
+++ b/django_reverse_admin/__init__.py
@@ -52,7 +52,7 @@ def reverse_inlineformset_factory(parent_model,
                           (f.one_to_many or f.one_to_one) and
                           f.auto_created and not f.concrete]
         fields = [f.name for f in model._meta.get_fields() if f not in
-                  related_fields]  # ignoring reverse relations
+                  related_fields if f.editable]  # ignoring reverse relations
     kwargs = {
         'form': form,
         'formfield_callback': formfield_callback,


### PR DESCRIPTION
The code currently errors out on models with `auto_now_add` and `auto_now` fields because those fields are marked as `editable=False`. This change filters out the non-editable fields.

Also, can you please enable Github Issues on your fork if this is to be the canonical version?

Thanks!